### PR TITLE
Replaced xmlhttprequest by request-promise-native

### DIFF
--- a/lib/authentication.js
+++ b/lib/authentication.js
@@ -39,15 +39,15 @@ function Authentication(socketAddress)
   checkUtils.checkSocketAddress(socketAddress);
 
   let _sessionToken = '';
-  let _defaultOptions =
-  {
-    url: 'http://' + socketAddress.ip + ':' + socketAddress.port + '/api/v1/authenticate',
-    headers: {
-      'Content-Type': 'application/x-www-form-urlencoded'
-    },
-    timeout: '100',
-    json: true
-  };
+  const _defaultOptions =
+    {
+      url: 'http://' + socketAddress.ip + ':' + socketAddress.port + '/api/v1/authenticate',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded'
+      },
+      timeout: '100',
+      json: true
+    };
 
 
   // Class prototype
@@ -80,10 +80,11 @@ function Authentication(socketAddress)
         return requestPromise.post(options, (error, response, body) =>
           {
             if (  !error
-               && (response.statusCode == 200)
-               && (body.data.clientToken !== 'undefined'))
+               && (response.statusCode === 200)
+               && (typeof body.data !== 'undefined')
+               && (typeof body.data.clientToken !== 'undefined'))
             {
-              _sessionToken = body.data.clientToken
+              _sessionToken = body.data.clientToken;
             }
           });
       },
@@ -111,7 +112,8 @@ function Authentication(socketAddress)
         return requestPromise.post(options, (error, response, body) =>
           {
             if (  !error
-               && (response.statusCode == 200)
+               && (response.statusCode === 200)
+               && (typeof body.message !== 'undefined')
                && (typeof body.message.success !== 'undefined'))
             {
               _sessionToken = '';

--- a/lib/authentication.js
+++ b/lib/authentication.js
@@ -1,8 +1,7 @@
 'use strict';
 
 let checkUtils     = require('./check-utils'),
-    XMLHttpRequest = require('xmlhttprequest').XMLHttpRequest,
-    Promise        = require('promise');
+    requestPromise = require('request-promise-native');
 
 
 /**
@@ -39,8 +38,16 @@ function Authentication(socketAddress)
 {
   checkUtils.checkSocketAddress(socketAddress);
 
-  const _url = 'http://' + socketAddress.ip + ':' + socketAddress.port + '/api/v1/authenticate';
   let _sessionToken = '';
+  let _defaultOptions =
+  {
+    url: 'http://' + socketAddress.ip + ':' + socketAddress.port + '/api/v1/authenticate',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded'
+    },
+    timeout: '100',
+    json: true
+  };
 
 
   // Class prototype
@@ -68,30 +75,16 @@ function Authentication(socketAddress)
         // Validate function parameters
         checkCredentials(credentials);
 
-        return new Promise((resolve, reject) =>
+        let options = JSON.parse(JSON.stringify(_defaultOptions));
+        options.body = 'command=signIn&user=' + credentials.username + '&password=' + credentials.password;
+        return requestPromise.post(options, (error, response, body) =>
           {
-            let request = new XMLHttpRequest();
-
-            request.onreadystatechange = () =>
-              {
-                if (request.readyState === 4) // 4 == DONE
-                {
-                  if (request.status === 200) // 200 == OK
-                  {
-                    _sessionToken = JSON.parse(request.responseText)['data']['clientToken'];
-                    resolve();
-                  }
-                  else
-                  {
-                    // TODO: Parse error message instead of dumping a JSON error.
-                    reject(request.responseText);
-                  }
-                }
-              }
-
-            request.open('POST', _url);
-            request.setRequestHeader('Content-Type', 'application/x-www-form-urlencoded');
-            request.send('command=signIn&user=' + credentials.username + '&password=' + credentials.password);
+            if (  !error
+               && (response.statusCode == 200)
+               && (body.data.clientToken !== 'undefined'))
+            {
+              _sessionToken = body.data.clientToken
+            }
           });
       },
 
@@ -113,40 +106,16 @@ function Authentication(socketAddress)
           throw new Error('Trying to sign out when not signed in');
         }
 
-        return new Promise((resolve, reject) =>
+        let options = JSON.parse(JSON.stringify(_defaultOptions));
+        options.body = 'command=signOut&clientToken=' + _sessionToken;
+        return requestPromise.post(options, (error, response, body) =>
           {
-            var request = new XMLHttpRequest();
-
-            request.onreadystatechange = () =>
-              {
-                if (request.readyState === 4) // 4 == DONE
-                {
-                  if (request.status === 200) // 200 == OK
-                  {
-                    var response = JSON.parse(request.responseText);
-                    if (  response.hasOwnProperty('message')
-                       && response['message'].hasOwnProperty('success'))
-                    {
-                      _sessionToken = '';
-                      resolve();
-                    }
-                    else
-                    {
-                      // TODO: Parse error message instead of dumping a JSON error.
-                      reject(request.responseText);
-                    }
-                  }
-                  else
-                  {
-                    // TODO: Parse error message instead of dumping a JSON error.
-                    reject(request.responseText);
-                  }
-                }
-              }
-
-            request.open('POST', _url);
-            request.setRequestHeader('Content-Type', 'application/x-www-form-urlencoded');
-            request.send('command=signOut&clientToken=' + _sessionToken);
+            if (  !error
+               && (response.statusCode == 200)
+               && (typeof body.message.success !== 'undefined'))
+            {
+              _sessionToken = '';
+            }
           });
       },
 
@@ -160,39 +129,10 @@ function Authentication(socketAddress)
        */
       verify()
       {
-        return new Promise((resolve, reject) =>
-          {
-            if (_sessionToken === '')
-            {
-              resolve(false);
-            }
-
-            let request = new XMLHttpRequest();
-
-            request.onreadystatechange = () =>
-              {
-                if (request.readyState === 4) // 4 == DONE
-                {
-                  if (request.status === 200) // 200 == OK
-                  {
-                    resolve(true);
-                  }
-                  else if (request.status === 401)
-                  {
-                    resolve(false);
-                  }
-                  else
-                  {
-                    // TODO: Parse error message instead of dumping a JSON error.
-                    reject(request.responseText);
-                  }
-                }
-              }
-
-            request.open('GET', _url + '?command=verify');
-            request.setRequestHeader('X-AUTHENTICATION-TOKEN', _sessionToken);
-            request.send();
-          });
+        let options = JSON.parse(JSON.stringify(_defaultOptions));
+        options.url = options.url + '?command=verify';
+        options.headers = { 'X-AUTHENTICATION-TOKEN': _sessionToken };
+        return requestPromise(options);
       },
 
 
@@ -231,4 +171,4 @@ function Authentication(socketAddress)
 
 
 // Define exports
-module.exports                    = Authentication;
+module.exports = Authentication;

--- a/lib/check-utils.js
+++ b/lib/check-utils.js
@@ -1,6 +1,6 @@
 'use strict';
 
-let validator      = require('validator');
+let validator = require('validator');
 
 
 /**

--- a/lib/configuration-adapter.js
+++ b/lib/configuration-adapter.js
@@ -142,14 +142,14 @@ function ConfigurationAdapter(socketAddress, sessionToken)
   checkUtils.checkSessionToken(sessionToken);
 
   const _defaultOptions =
-  {
-    url: 'http://' + socketAddress.ip + ':' + socketAddress.port + '/api/v1/config',
-    headers: {
-      'X-AUTHENTICATION-TOKEN': sessionToken
-    },
-    timeout: '100',
-    json: true
-  }
+    {
+      url: 'http://' + socketAddress.ip + ':' + socketAddress.port + '/api/v1/config',
+      headers: {
+        'X-AUTHENTICATION-TOKEN': sessionToken
+      },
+      timeout: '100',
+      json: true
+    }
 
   /**
    * Query for an entity in the ViSense system. This function will sign in to acquire a

--- a/lib/configuration-adapter.js
+++ b/lib/configuration-adapter.js
@@ -1,7 +1,7 @@
 'use strict';
 
 let checkUtils     = require('./check-utils'),
-    XMLHttpRequest = require('xmlhttprequest').XMLHttpRequest;
+    requestPromise = require('request-promise-native');
 
 
 /**
@@ -15,15 +15,13 @@ let checkUtils     = require('./check-utils'),
  */
 function extractResponseData(response)
 {
-  let responseObject = JSON.parse(response);
-
-  if (  (typeof responseObject !== 'object')
-     || (typeof responseObject.data === 'undefined'))
+  if (  (typeof response !== 'object')
+     || (typeof response.data === 'undefined'))
   {
     throw Error('Not a data response');
   }
 
-  return responseObject.data;
+  return response.data;
 }
 
 
@@ -69,8 +67,6 @@ function extractParameterValue(response)
     }
 
     throw Error('Failed to extract parameter value');
-
-    return '';
   }
 
   return String(iterate(extractResponseData(response)));
@@ -119,8 +115,6 @@ function extractSignalState(response)
     }
 
     throw Error('Failed to extract signal state value');
-
-    return '';
   }
 
   return String(iterate(extractResponseData(response)));
@@ -147,7 +141,15 @@ function ConfigurationAdapter(socketAddress, sessionToken)
   checkUtils.checkSocketAddress(socketAddress);
   checkUtils.checkSessionToken(sessionToken);
 
-  const _url = 'http://' + socketAddress.ip + ':' + socketAddress.port + '/api/v1/config';
+  const _defaultOptions =
+  {
+    url: 'http://' + socketAddress.ip + ':' + socketAddress.port + '/api/v1/config',
+    headers: {
+      'X-AUTHENTICATION-TOKEN': sessionToken
+    },
+    timeout: '100',
+    json: true
+  }
 
   /**
    * Query for an entity in the ViSense system. This function will sign in to acquire a
@@ -164,29 +166,9 @@ function ConfigurationAdapter(socketAddress, sessionToken)
   {
     let queryResult = '';
 
-    return new Promise((resolve, reject) =>
-      {
-        let request = new XMLHttpRequest();
-
-        request.onreadystatechange = () =>
-          {
-            if (request.readyState === 4) // 4 == DONE
-            {
-              if (request.status === 200) // 200 == OK
-              {
-                resolve(request.responseText);
-              }
-              else
-              {
-                reject(request.responseText);
-              }
-            }
-          }
-
-        request.open('GET', _url + '?command=get&select=' + name + '&filter=' + type + '&format=json-value-v1');
-        request.setRequestHeader('X-AUTHENTICATION-TOKEN', sessionToken);
-        request.send();
-      });
+    let options = JSON.parse(JSON.stringify(_defaultOptions));
+    options.url += '?command=get&select=' + name + '&filter=' + type + '&format=json-value-v1';
+    return requestPromise.get(options);
   }
 
 

--- a/lib/websocket-connection.js
+++ b/lib/websocket-connection.js
@@ -127,7 +127,7 @@ function WebSocketConnection(socketAddress, url, sessionToken)
       {
         if (!_webSocket)
         {
-          return Promise.resolve();
+          throw Error('WebSocket is not opened');
         }
 
         return new Promise((resolve, reject) =>

--- a/lib/websocket-connection.js
+++ b/lib/websocket-connection.js
@@ -1,8 +1,7 @@
 'use strict';
 
 let checkUtils = require('./check-utils'),
-    WebSocket  = require('ws'),
-    Promise    = require('promise');
+    WebSocket  = require('ws');
 
 
 /**

--- a/package.json
+++ b/package.json
@@ -18,15 +18,15 @@
   "dependencies": {
     "commander": "~2.8.x",
     "validator": "~5.5.x",
-    "xmlhttprequest": "~1.8.x",
-    "promise": "~7.x",
-    "ws": "~2.2.x"
+    "ws": "~2.2.x",
+    "request": "~2.81.0",
+    "request-promise-native": "~1.0.4"
   },
   "bin": {
     "visense-authentication": "./bin/visense-authentication",
     "visense-systeminfo": "./bin/visense-systeminfo"
   },
   "scripts": {
-    "test": "qunit -c ./index.js -t ./tests/all-tests.js"
+    "test": "node ./tests/all-tests.js"
   }
 }

--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
     "commander": "~2.8.x",
     "validator": "~5.5.x",
     "ws": "~2.2.x",
-    "request": "~2.81.0",
-    "request-promise-native": "~1.0.4"
+    "request": "~2.81.x",
+    "request-promise-native": "~1.0.x"
   },
   "bin": {
     "visense-authentication": "./bin/visense-authentication",

--- a/tests/all-tests.js
+++ b/tests/all-tests.js
@@ -1,6 +1,26 @@
 'use strict';
 
-let AuthenticationTests       = require('./authentication-tests'),
-    ConfigurationAdapterTests = require('./configuration-adapter-tests'),
-    VisenseSystemTests        = require('./visense-system-tests'),
-    WebsocketConnectionTests  = require('./websocket-connection-tests');
+let testrunner = require('qunit');
+
+testrunner.run([
+  {
+    code: "./index.js",
+    tests: [
+      "./tests/authentication-tests",
+      "./tests/configuration-adapter-tests",
+      './tests/visense-system-tests',
+      './tests/websocket-connection-tests'
+    ]
+  }
+], (error, report) =>
+  {
+    console.log("Report: ", report);
+    if (error) console.error("Exception in QUnit TestRunner: ", error);
+
+    if (  (typeof report === 'undefined')
+       || (  (typeof report.failed !== 'undefined')
+          && (report.failed > 0)))
+    {
+      process.exitCode = 1;
+    }
+  });

--- a/tests/all-tests.js
+++ b/tests/all-tests.js
@@ -2,25 +2,26 @@
 
 let testrunner = require('qunit');
 
-testrunner.run([
-  {
-    code: "./index.js",
-    tests: [
-      "./tests/authentication-tests",
-      "./tests/configuration-adapter-tests",
-      './tests/visense-system-tests',
-      './tests/websocket-connection-tests'
-    ]
-  }
-], (error, report) =>
-  {
-    console.log("Report: ", report);
-    if (error) console.error("Exception in QUnit TestRunner: ", error);
-
-    if (  (typeof report === 'undefined')
-       || (  (typeof report.failed !== 'undefined')
-          && (report.failed > 0)))
+testrunner.run(
+  [
     {
-      process.exitCode = 1;
+      code: './index.js',
+      tests: [
+        './tests/authentication-tests',
+        './tests/configuration-adapter-tests',
+        './tests/visense-system-tests',
+        './tests/websocket-connection-tests'
+      ]
     }
-  });
+  ], (error, report) =>
+    {
+      console.log('Report: ', report);
+      if (error) console.error('Exception in QUnit TestRunner: ', error);
+
+      if (  (typeof report === 'undefined')
+        || (  (typeof report.failed !== 'undefined')
+            && (report.failed > 0)))
+      {
+        process.exitCode = 1;
+      }
+    });

--- a/tests/authentication-tests.js
+++ b/tests/authentication-tests.js
@@ -95,7 +95,7 @@ test('signIn function', (assert) =>
     assert.ok((() =>
       {
         // Check if the returned value is a Promise (the signIn action will fail)
-        return (typeof x.signIn({ username: 'dsfnjskjn3', password: 'kjfuisqh3' }).catch(error => {}) === 'object');
+        return (typeof x.signIn({ username: 'dsfnjskjn3', password: 'kjfuisqh3' }).catch(() => {}) === 'object');
       })(), 'Valid function call');
   });
 
@@ -119,7 +119,7 @@ test('signOut function', (assert) =>
     assert.ok((() =>
       {
         // Check if the returned value is a Promise (the signOut action will fail)
-        return (typeof x.signOut().catch(error => {}) === 'object');
+        return (typeof x.signOut().catch(() => {}) === 'object');
       })(), 'Valid function call');
   });
 
@@ -135,7 +135,7 @@ test('verify function', (assert) =>
     assert.ok((() =>
       {
         // Check if the returned value is a Promise (the verify action will fail)
-        return (typeof x.verify().catch(error => {}) === 'object');
+        return (typeof x.verify().catch(() => {}) === 'object');
       })(), 'Valid function call');
   });
 

--- a/tests/authentication-tests.js
+++ b/tests/authentication-tests.js
@@ -95,7 +95,7 @@ test('signIn function', (assert) =>
     assert.ok((() =>
       {
         // Check if the returned value is a Promise (the signIn action will fail)
-        return (typeof x.signIn({ username: 'dsfnjskjn3', password: 'kjfuisqh3' }).then === 'function');
+        return (typeof x.signIn({ username: 'dsfnjskjn3', password: 'kjfuisqh3' }).catch(error => {}) === 'object');
       })(), 'Valid function call');
   });
 
@@ -119,7 +119,7 @@ test('signOut function', (assert) =>
     assert.ok((() =>
       {
         // Check if the returned value is a Promise (the signOut action will fail)
-        return (typeof x.signOut().then === 'function');
+        return (typeof x.signOut().catch(error => {}) === 'object');
       })(), 'Valid function call');
   });
 
@@ -135,7 +135,7 @@ test('verify function', (assert) =>
     assert.ok((() =>
       {
         // Check if the returned value is a Promise (the verify action will fail)
-        return (typeof x.verify().then === 'function');
+        return (typeof x.verify().catch(error => {}) === 'object');
       })(), 'Valid function call');
   });
 

--- a/tests/configuration-adapter-tests.js
+++ b/tests/configuration-adapter-tests.js
@@ -84,7 +84,7 @@ test('queryParameter function', (assert) =>
         const x = ConfigurationAdapter({ ip: '127.0.0.1', port: 80 }, 'dummy');
 
         // Check if the returned value is a Promise (the query will fail)
-        return (typeof x.queryParameter('').catch(error => {}) === 'object');
+        return (typeof x.queryParameter('').catch(() => {}) === 'object');
       })(), 'Valid function call');
   });
 
@@ -99,6 +99,6 @@ test('querySignal function', (assert) =>
         const x = ConfigurationAdapter({ ip: '127.0.0.1', port: 80 }, 'dummy');
 
         // Check if the returned value is a Promise (the query will fail)
-        return (typeof x.querySignal('').catch(error => {}) === 'object');
+        return (typeof x.querySignal('').catch(() => {}) === 'object');
       })(), 'Valid function call');
   });

--- a/tests/configuration-adapter-tests.js
+++ b/tests/configuration-adapter-tests.js
@@ -84,7 +84,7 @@ test('queryParameter function', (assert) =>
         const x = ConfigurationAdapter({ ip: '127.0.0.1', port: 80 }, 'dummy');
 
         // Check if the returned value is a Promise (the query will fail)
-        return (typeof x.queryParameter('').then === 'function');
+        return (typeof x.queryParameter('').catch(error => {}) === 'object');
       })(), 'Valid function call');
   });
 
@@ -99,6 +99,6 @@ test('querySignal function', (assert) =>
         const x = ConfigurationAdapter({ ip: '127.0.0.1', port: 80 }, 'dummy');
 
         // Check if the returned value is a Promise (the query will fail)
-        return (typeof x.querySignal('').then === 'function');
+        return (typeof x.querySignal('').catch(error => {}) === 'object');
       })(), 'Valid function call');
   });

--- a/tests/visense-system-tests.js
+++ b/tests/visense-system-tests.js
@@ -119,7 +119,7 @@ test('queryProductName function', (assert) =>
         const x = ViSenseSystem({ ip: '127.0.0.1', port: 80 }, 'dummy');
 
         // Check if the returned value is a Promise (the query will fail)
-        return (typeof x.queryProductName().catch(error => {}) === 'object');
+        return (typeof x.queryProductName().catch(() => {}) === 'object');
       })(), 'Valid function call');
   });
 
@@ -134,7 +134,7 @@ test('queryServiceTag function', (assert) =>
         const x = ViSenseSystem({ ip: '127.0.0.1', port: 80 }, 'dummy');
 
         // Check if the returned value is a Promise (the query will fail)
-        return (typeof x.queryServiceTag().catch(error => {}) === 'object');
+        return (typeof x.queryServiceTag().catch(() => {}) === 'object');
       })(), 'Valid function call');
   });
 
@@ -149,6 +149,6 @@ test('queryConnectionStatus function', (assert) =>
         const x = ViSenseSystem({ ip: '127.0.0.1', port: 80 }, 'dummy');
 
         // Check if the returned value is a Promise (the query will fail)
-        return (typeof x.queryConnectionStatus().catch(error => {}) === 'object');
+        return (typeof x.queryConnectionStatus().catch(() => {}) === 'object');
       })(), 'Valid function call');
   });

--- a/tests/visense-system-tests.js
+++ b/tests/visense-system-tests.js
@@ -119,7 +119,7 @@ test('queryProductName function', (assert) =>
         const x = ViSenseSystem({ ip: '127.0.0.1', port: 80 }, 'dummy');
 
         // Check if the returned value is a Promise (the query will fail)
-        return (typeof x.queryProductName().then === 'function');
+        return (typeof x.queryProductName().catch(error => {}) === 'object');
       })(), 'Valid function call');
   });
 
@@ -134,7 +134,7 @@ test('queryServiceTag function', (assert) =>
         const x = ViSenseSystem({ ip: '127.0.0.1', port: 80 }, 'dummy');
 
         // Check if the returned value is a Promise (the query will fail)
-        return (typeof x.queryServiceTag().then === 'function');
+        return (typeof x.queryServiceTag().catch(error => {}) === 'object');
       })(), 'Valid function call');
   });
 
@@ -149,6 +149,6 @@ test('queryConnectionStatus function', (assert) =>
         const x = ViSenseSystem({ ip: '127.0.0.1', port: 80 }, 'dummy');
 
         // Check if the returned value is a Promise (the query will fail)
-        return (typeof x.queryConnectionStatus().then === 'function');
+        return (typeof x.queryConnectionStatus().catch(error => {}) === 'object');
       })(), 'Valid function call');
   });

--- a/tests/websocket-connection-tests.js
+++ b/tests/websocket-connection-tests.js
@@ -89,7 +89,7 @@ test('open function', (assert) =>
         const x = WebSocketConnection({ ip: '127.0.0.1', port: 80 }, 'dummy', 'dummy');
 
         // Check if the returned value is a Promise (the call will fail)
-        return (typeof x.open().then === 'function');
+        return (typeof x.open().catch(error => {}) === 'object');
       })(), 'Valid function call');
   });
 
@@ -102,6 +102,8 @@ test('send function', (assert) =>
     assert.throws(() =>
       {
         const x = WebSocketConnection({ ip: '127.0.0.1', port: 80 }, 'dummy', 'dummy');
+
+        // Websocket is not open, method will throw.
         x.send('', null);
       }, 'Send query when the WebSocketConnection is not opened yet');
   });
@@ -116,7 +118,7 @@ test('close function', (assert) =>
       {
         const x = WebSocketConnection({ ip: '127.0.0.1', port: 80 }, 'dummy', 'dummy');
 
-        // Check if the returned value is a Promise (the call will fail)
+        // Check if the returned value is a Promise (the call will not fail)
         return (typeof x.close().then === 'function');
       })(), 'Valid function call');
   });

--- a/tests/websocket-connection-tests.js
+++ b/tests/websocket-connection-tests.js
@@ -89,7 +89,7 @@ test('open function', (assert) =>
         const x = WebSocketConnection({ ip: '127.0.0.1', port: 80 }, 'dummy', 'dummy');
 
         // Check if the returned value is a Promise (the call will fail)
-        return (typeof x.open().catch(error => {}) === 'object');
+        return (typeof x.open().catch(() => {}) === 'object');
       })(), 'Valid function call');
   });
 
@@ -120,5 +120,5 @@ test('close function', (assert) =>
 
         // Websocket is not open, method will throw.
         x.close()
-      }, 'Close when the WebSocketConnection is not opened yet');
+      }, 'Close when the WebSocket connection is not opened yet');
   });

--- a/tests/websocket-connection-tests.js
+++ b/tests/websocket-connection-tests.js
@@ -114,11 +114,11 @@ test('close function', (assert) =>
     // Tell QUnit to expect a fixed number of assertions (to prevent missing silent fails)
     assert.expect(1);
 
-    assert.ok((() =>
+    assert.throws(() =>
       {
         const x = WebSocketConnection({ ip: '127.0.0.1', port: 80 }, 'dummy', 'dummy');
 
-        // Check if the returned value is a Promise (the call will not fail)
-        return (typeof x.close().then === 'function');
-      })(), 'Valid function call');
+        // Websocket is not open, method will throw.
+        x.close()
+      }, 'Close when the WebSocketConnection is not opened yet');
   });


### PR DESCRIPTION
Also,
- Request results are automatically parsed to JSON-format,
- WebSocketConnection close() throws when no connection was opened,
- Native implementation of Promise is now used,
- Tests yielding uncaught rejection warnings have been fixed,
- QUnit testrunner API to run tests.