### PR TITLE
CHG: rename query >> get.

### DIFF
--- a/lib/configuration-adapter.js
+++ b/lib/configuration-adapter.js
@@ -170,6 +170,25 @@ function ConfigurationAdapter(socketAddress, sessionToken)
   }
 
 
+  /**
+   * Set an entity in the ViSense system.
+   *
+   * @param {string} name The query entity name.
+   * @param {string} type The query entity type.
+   * @param {string} value The new value of the query entity.
+   *
+   * @returns {object} A promise with the query result. The resolve/reject callback prototypes
+   *                    are: - resolve({string} query result)
+   *                         - reject({string} error message)
+   */
+  function set(name, type, value)
+  {
+    let options = JSON.parse(JSON.stringify(_defaultOptions));
+    options.url += '?command=set&' + name + '=' + value + '&filter=' + type;
+    return requestPromise.get(options);
+  }
+
+
   // Class prototype
   let ConfigurationAdapterProto =
     {
@@ -200,6 +219,38 @@ function ConfigurationAdapter(socketAddress, sessionToken)
       getSignal(name)
       {
         return get(name, 'signal').then(extractSignalState);
+      },
+
+
+      /**
+       * Set a parameter.
+       *
+       * @param {string} name The parameter name.
+       * @param {string} value The new value of the parameter.
+       *
+       * @returns {object} A promise with the query. The resolve/reject callback prototypes
+       *                    are: - resolve({string} parameter value)
+       *                         - reject({string} error message)
+       */
+      setParameter(name, value)
+      {
+        return set(name, 'parameter', value);
+      },
+
+
+      /**
+       * Set an event signal.
+       *
+       * @param {string} name The signal name.
+       * @param {string} value The new value of the signal.
+       *
+       * @returns {object} A promise with the query. The resolve/reject callback prototypes
+       *                    are: - resolve({string} signal state)
+       *                         - reject({string} error message)
+       */
+      setSignal(name, value)
+      {
+        return set(name, 'signal', value);
       }
     };
 

--- a/lib/configuration-adapter.js
+++ b/lib/configuration-adapter.js
@@ -162,10 +162,8 @@ function ConfigurationAdapter(socketAddress, sessionToken)
    *                    are: - resolve({string} query result)
    *                         - reject({string} error message)
    */
-  function query(name, type)
+  function get(name, type)
   {
-    let queryResult = '';
-
     let options = JSON.parse(JSON.stringify(_defaultOptions));
     options.url += '?command=get&select=' + name + '&filter=' + type + '&format=json-value-v1';
     return requestPromise.get(options);
@@ -176,7 +174,7 @@ function ConfigurationAdapter(socketAddress, sessionToken)
   let ConfigurationAdapterProto =
     {
       /**
-       * Query for a parameter.
+       * Get a parameter.
        *
        * @param {string} name The parameter name.
        *
@@ -184,14 +182,14 @@ function ConfigurationAdapter(socketAddress, sessionToken)
        *                    are: - resolve({string} parameter value)
        *                         - reject({string} error message)
        */
-      queryParameter(name)
+      getParameter(name)
       {
-        return query(name, 'parameter').then(extractParameterValue);
+        return get(name, 'parameter').then(extractParameterValue);
       },
 
 
       /**
-       * Query for an event signal.
+       * Get an event signal.
        *
        * @param {string} name The signal name.
        *
@@ -199,9 +197,9 @@ function ConfigurationAdapter(socketAddress, sessionToken)
        *                    are: - resolve({string} signal state)
        *                         - reject({string} error message)
        */
-      querySignal(name)
+      getSignal(name)
       {
-        return query(name, 'signal').then(extractSignalState);
+        return get(name, 'signal').then(extractSignalState);
       }
     };
 

--- a/lib/configuration-adapter.js
+++ b/lib/configuration-adapter.js
@@ -239,18 +239,18 @@ function ConfigurationAdapter(socketAddress, sessionToken)
 
 
       /**
-       * Set an event signal.
+       * Set an event slot.
        *
-       * @param {string} name The signal name.
-       * @param {string} value The new value of the signal.
+       * @param {string} name The slot name.
+       * @param {string} value The new value of the slot.
        *
        * @returns {object} A promise with the query. The resolve/reject callback prototypes
-       *                    are: - resolve({string} signal state)
+       *                    are: - resolve({string} slot info)
        *                         - reject({string} error message)
        */
-      setSignal(name, value)
+      setSlot(name, value)
       {
-        return set(name, 'signal', value);
+        return set(name, 'slot', value);
       }
     };
 

--- a/lib/visense-system.js
+++ b/lib/visense-system.js
@@ -52,7 +52,7 @@ function ViSenseSystem(socketAddress, sessionToken, id)
 
 
       /**
-       * Query for the product name.
+       * Get the product name.
        *
        * @returns {object} A promise with the query. The resolve/reject callback
        *                    prototypes are: - resolve({string} product name)
@@ -60,12 +60,12 @@ function ViSenseSystem(socketAddress, sessionToken, id)
        */
       queryProductName()
       {
-        return _configAdapter.queryParameter('Application/Services/Device/ProductName');
+        return _configAdapter.getParameter('Application/Services/Device/ProductName');
       },
 
 
       /**
-       * Query for the system service tag.
+       * Get the system service tag.
        *
        * @returns {object} A promise with the query. The resolve/reject callback
        *                    prototypes are: - resolve({string} service tag)
@@ -73,12 +73,12 @@ function ViSenseSystem(socketAddress, sessionToken, id)
        */
       queryServiceTag()
       {
-        return _configAdapter.queryParameter('Application/Services/Device/ServiceTag');
+        return _configAdapter.getParameter('Application/Services/Device/ServiceTag');
       },
 
 
       /**
-       * Query for the system camera connection status.
+       * Get the system camera connection status.
        *
        * @returns {object} A promise with the query. The resolve/reject callback
        *                    prototypes are: - resolve({string} connection status)
@@ -86,7 +86,7 @@ function ViSenseSystem(socketAddress, sessionToken, id)
        */
       queryConnectionStatus()
       {
-        return _configAdapter.querySignal('Application/Channel/Video/Capture/ConnectionStatus');
+        return _configAdapter.getSignal('Application/Channel/Video/Capture/ConnectionStatus');
       }
     };
 

--- a/lib/visense-system.js
+++ b/lib/visense-system.js
@@ -58,7 +58,7 @@ function ViSenseSystem(socketAddress, sessionToken, id)
        *                    prototypes are: - resolve({string} product name)
        *                                    - reject({string} error message)
        */
-      queryProductName()
+      getProductName()
       {
         return _configAdapter.getParameter('Application/Services/Device/ProductName');
       },
@@ -71,7 +71,7 @@ function ViSenseSystem(socketAddress, sessionToken, id)
        *                    prototypes are: - resolve({string} service tag)
        *                                    - reject({string} error message)
        */
-      queryServiceTag()
+      getServiceTag()
       {
         return _configAdapter.getParameter('Application/Services/Device/ServiceTag');
       },
@@ -84,7 +84,7 @@ function ViSenseSystem(socketAddress, sessionToken, id)
        *                    prototypes are: - resolve({string} connection status)
        *                                    - reject({string} error message)
        */
-      queryConnectionStatus()
+      getConnectionStatus()
       {
         return _configAdapter.getSignal('Application/Channel/Video/Capture/ConnectionStatus');
       }

--- a/tests/configuration-adapter-tests.js
+++ b/tests/configuration-adapter-tests.js
@@ -74,7 +74,7 @@ test('Factory function', (assert) =>
   });
 
 
-test('queryParameter function', (assert) =>
+test('getParameter function', (assert) =>
   {
     // Tell QUnit to expect a fixed number of assertions (to prevent missing silent fails)
     assert.expect(1);
@@ -84,12 +84,12 @@ test('queryParameter function', (assert) =>
         const x = ConfigurationAdapter({ ip: '127.0.0.1', port: 80 }, 'dummy');
 
         // Check if the returned value is a Promise (the query will fail)
-        return (typeof x.queryParameter('').catch(() => {}) === 'object');
+        return (typeof x.getParameter('').catch(() => {}) === 'object');
       })(), 'Valid function call');
   });
 
 
-test('querySignal function', (assert) =>
+test('setParameter function', (assert) =>
   {
     // Tell QUnit to expect a fixed number of assertions (to prevent missing silent fails)
     assert.expect(1);
@@ -99,6 +99,6 @@ test('querySignal function', (assert) =>
         const x = ConfigurationAdapter({ ip: '127.0.0.1', port: 80 }, 'dummy');
 
         // Check if the returned value is a Promise (the query will fail)
-        return (typeof x.querySignal('').catch(() => {}) === 'object');
+        return (typeof x.setParameter('', '').catch(() => {}) === 'object');
       })(), 'Valid function call');
   });

--- a/tests/configuration-adapter-tests.js
+++ b/tests/configuration-adapter-tests.js
@@ -119,7 +119,7 @@ test('getSignal function', (assert) =>
   });
 
 
-test('setSignal function', (assert) =>
+test('setSlot function', (assert) =>
   {
     // Tell QUnit to expect a fixed number of assertions (to prevent missing silent fails)
     assert.expect(1);
@@ -129,6 +129,6 @@ test('setSignal function', (assert) =>
         const x = ConfigurationAdapter({ ip: '127.0.0.1', port: 80 }, 'dummy');
 
         // Check if the returned value is a Promise (the query will fail)
-        return (typeof x.setSignal('', '').catch(() => {}) === 'object');
+        return (typeof x.setSlot('', '').catch(() => {}) === 'object');
       })(), 'Valid function call');
   });

--- a/tests/configuration-adapter-tests.js
+++ b/tests/configuration-adapter-tests.js
@@ -102,3 +102,33 @@ test('setParameter function', (assert) =>
         return (typeof x.setParameter('', '').catch(() => {}) === 'object');
       })(), 'Valid function call');
   });
+
+
+test('getSignal function', (assert) =>
+  {
+    // Tell QUnit to expect a fixed number of assertions (to prevent missing silent fails)
+    assert.expect(1);
+
+    assert.ok((() =>
+      {
+        const x = ConfigurationAdapter({ ip: '127.0.0.1', port: 80 }, 'dummy');
+
+        // Check if the returned value is a Promise (the query will fail)
+        return (typeof x.getSignal('').catch(() => {}) === 'object');
+      })(), 'Valid function call');
+  });
+
+
+test('setSignal function', (assert) =>
+  {
+    // Tell QUnit to expect a fixed number of assertions (to prevent missing silent fails)
+    assert.expect(1);
+
+    assert.ok((() =>
+      {
+        const x = ConfigurationAdapter({ ip: '127.0.0.1', port: 80 }, 'dummy');
+
+        // Check if the returned value is a Promise (the query will fail)
+        return (typeof x.setSignal('', '').catch(() => {}) === 'object');
+      })(), 'Valid function call');
+  });

--- a/tests/visense-system-tests.js
+++ b/tests/visense-system-tests.js
@@ -109,7 +109,7 @@ test('getId function', (assert) =>
   });
 
 
-test('queryProductName function', (assert) =>
+test('getProductName function', (assert) =>
   {
     // Tell QUnit to expect a fixed number of assertions (to prevent missing silent fails)
     assert.expect(1);
@@ -119,12 +119,12 @@ test('queryProductName function', (assert) =>
         const x = ViSenseSystem({ ip: '127.0.0.1', port: 80 }, 'dummy');
 
         // Check if the returned value is a Promise (the query will fail)
-        return (typeof x.queryProductName().catch(() => {}) === 'object');
+        return (typeof x.getProductName().catch(() => {}) === 'object');
       })(), 'Valid function call');
   });
 
 
-test('queryServiceTag function', (assert) =>
+test('getServiceTag function', (assert) =>
   {
     // Tell QUnit to expect a fixed number of assertions (to prevent missing silent fails)
     assert.expect(1);
@@ -134,12 +134,12 @@ test('queryServiceTag function', (assert) =>
         const x = ViSenseSystem({ ip: '127.0.0.1', port: 80 }, 'dummy');
 
         // Check if the returned value is a Promise (the query will fail)
-        return (typeof x.queryServiceTag().catch(() => {}) === 'object');
+        return (typeof x.getServiceTag().catch(() => {}) === 'object');
       })(), 'Valid function call');
   });
 
 
-test('queryConnectionStatus function', (assert) =>
+test('getConnectionStatus function', (assert) =>
   {
     // Tell QUnit to expect a fixed number of assertions (to prevent missing silent fails)
     assert.expect(1);
@@ -149,6 +149,6 @@ test('queryConnectionStatus function', (assert) =>
         const x = ViSenseSystem({ ip: '127.0.0.1', port: 80 }, 'dummy');
 
         // Check if the returned value is a Promise (the query will fail)
-        return (typeof x.queryConnectionStatus().catch(() => {}) === 'object');
+        return (typeof x.getConnectionStatus().catch(() => {}) === 'object');
       })(), 'Valid function call');
   });


### PR DESCRIPTION
Rename any query() methods to get(), so that set() methods can be implemented.