### PR TITLE
Change parameter name from url to apiPath

### DIFF
--- a/lib/websocket-connection.js
+++ b/lib/websocket-connection.js
@@ -11,7 +11,7 @@ const checkUtils = require('./check-utils'),
  *
  * @param {object}  socketAddress ViSense system socket address.
  * @param {boolean} useSsl        Flag to indicate whether or not to use SSL.
- * @param {string}  apiPath       ViSense API Path (e.g. '/api/v2/data/main/count/preset0').
+ * @param {string}  apiPath       ViSense API path (e.g. '/api/v2/data/main/count/preset0').
  * @param {string}  sessionToken  Authentication session token.
  *
  * @returns {object} WebSocketConnection object instance.
@@ -30,7 +30,7 @@ function WebSocketConnection(socketAddress, useSsl, apiPath, sessionToken) {
 
   if (  !checkUtils.isDefinedString(apiPath)
      || (apiPath.length === 0)) {
-    throw Error('Parameter \'path: ""\' is invalid or empty');
+    throw Error('Parameter \'apiPath: ""\' is invalid or empty');
   }
 
   // Private class members.

--- a/lib/websocket-connection.js
+++ b/lib/websocket-connection.js
@@ -11,14 +11,14 @@ const checkUtils = require('./check-utils'),
  *
  * @param {object}  socketAddress ViSense system socket address.
  * @param {boolean} useSsl        Flag to indicate whether or not to use SSL.
- * @param {string}  url           ViSense API URL (e.g. '/api/v2/data/main/count/preset0').
+ * @param {string}  apiPath       ViSense API Path (e.g. '/api/v2/data/main/count/preset0').
  * @param {string}  sessionToken  Authentication session token.
  *
  * @returns {object} WebSocketConnection object instance.
  *
  * @throws When invalid function parameters are provided.
  */
-function WebSocketConnection(socketAddress, useSsl, url, sessionToken) {
+function WebSocketConnection(socketAddress, useSsl, apiPath, sessionToken) {
 
   // Validate function parameters.
   checkUtils.checkSocketAddress(socketAddress);
@@ -28,14 +28,14 @@ function WebSocketConnection(socketAddress, useSsl, url, sessionToken) {
 
   checkUtils.checkSessionToken(sessionToken);
 
-  if (  !checkUtils.isDefinedString(url)
-     || (url.length === 0)) {
-    throw Error('Parameter \'url: ""\' is invalid or empty');
+  if (  !checkUtils.isDefinedString(apiPath)
+     || (apiPath.length === 0)) {
+    throw Error('Parameter \'path: ""\' is invalid or empty');
   }
 
   // Private class members.
   let _webSocket = null;
-  const _url = (useSsl ? 'wss://' : 'ws://') + socketAddress.ip + ':' + socketAddress.port + url + '?X-AUTHENTICATION-TOKEN=' + sessionToken;
+  const _url = (useSsl ? 'wss://' : 'ws://') + socketAddress.ip + ':' + socketAddress.port + apiPath + '?X-AUTHENTICATION-TOKEN=' + sessionToken;
 
 
   const _reset = () => {


### PR DESCRIPTION
This is more descriptive in what it represents. A parameter named URL
indicates it should also include a scheme, a FQDN and optionally a port
but these values have already been provided by the `socketAddress`
parameter.