### PR TITLE
Add typings to the package

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "url": "https://github.com/vinotion/visense-tools.git"
   },
   "main": "index.js",
+  "types": "./types/index.d.ts",
   "dependencies": {
     "commander": "~4.1.x",
     "validator": "~12.2.x",

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -42,7 +42,7 @@ declare module "visense-tools" {
 
 
     class WebSocketConnection {
-        constructor(socketAddress: SocketAddress, useSsl: boolean, url: string, sessionToken: string);
+        constructor(socketAddress: SocketAddress, useSsl: boolean, apiPath: string, sessionToken: string);
 
         open(): Promise<void>;
         close(): Promise<void>;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,0 +1,53 @@
+declare module "visense-tools" {
+    interface Credentials {
+        username: string;
+        password: string;
+    }
+
+    interface SocketAddress {
+        ip: string;
+        port: number;
+    }
+
+    class Authentication {
+        constructor(socketAddress: SocketAddress, useSsl: boolean);
+
+        signIn(credentials: Credentials): Promise<void>;
+        signOut(): Promise<void>;
+        verify(): Promise<boolean>;
+
+        getSessionToken(): string;
+        setSessionToken(sessionToken: string): void;
+    }
+
+    class ConfigurationAdapter {
+        constructor(socketAddress: SocketAddress, useSsl: boolean, sessionToken: string);
+
+        getParameter(name: string): Promise<string>;
+        setParameter(name: string, value: string): Promise<string>;
+
+        getSignal(name: string): Promise<string>;
+
+        setSlot(name: string, value: string): Promise<string>;
+    }
+
+    class ViSenseSystem {
+        constructor(socketAddress: SocketAddress, useSsl: boolean, sessionToken: string, id: string);
+
+        getId(): string;
+        getProductName(): Promise<string>;
+        getServiceTag(): Promise<string>;
+        getConnectionStatus(): Promise<string>;
+    }
+
+
+    class WebSocketConnection {
+        constructor(socketAddress: SocketAddress, useSsl: boolean, url: string, sessionToken: string);
+
+        open(): Promise<void>;
+        close(): Promise<void>;
+
+        send(query: string, onDataCallback: (data: any|null) => boolean, timeout: number): Promise<void>;
+        send(query: string, onDataCallback: (data: any|null) => boolean): Promise<void>;
+    }
+}


### PR DESCRIPTION
Add TypeScript typings to the package for a more clean integration with
clients that use TypeScript as a preferred language. This way syntatic
sugar like the following is allowed:

```
import {WebSocketConnection} from "visense-tools";

let socket = new WebSocketConnection(socketAddress, true, '/api/v2/data/main/events', 'xx-xx-xx-xx');;
```

I intentionally did not include the `check-utils` library since it is, in my opinion, to be considered internal and thus not exposed to the public API.