### PR TITLE
FIX: websocket-connection.js compatibility with Node v24

### DIFF
--- a/lib/websocket-connection.js
+++ b/lib/websocket-connection.js
@@ -151,7 +151,7 @@ function WebSocketConnection(socketAddress, useSsl, apiPath, sessionToken) {
         _webSocket.on('error',   onError);
 
         _webSocket.send(query, { mask: true }, (error) => {
-          if (typeof error !== 'undefined') {
+          if (error) {
             removeEventListeners();
             reject(error.message);
           }


### PR DESCRIPTION
ws on node v24 returns 'null' instead of 'undefined' when connected correctly.